### PR TITLE
Fix LCD_FillRect and ILI9341_SendRepeatedDataDMA

### DIFF
--- a/Firmware/Test/Drivers/external/Inc/lcd_ili9341.h
+++ b/Firmware/Test/Drivers/external/Inc/lcd_ili9341.h
@@ -103,7 +103,7 @@ void    ILI9341_SetAddress (LCD_IO_Data_t *address);
 void    ILI9341_SendData(LCD_IO_Data_t *data, uint32_t length);
 void    ILI9341_SendRepeatedData(LCD_IO_Data_t data, uint32_t num_copies);
 int32_t ILI9341_SendDataDMA(LCD_IO_Data_t *data, uint32_t length);
-int32_t	ILI9341_SendRepeatedDataDMA(LCD_IO_Data_t data, uint32_t num_copies);
+int32_t	ILI9341_SendRepeatedDataDMA(LCD_IO_Data_t *data, uint32_t num_copies);
 void    ILI9341_RecvData(LCD_IO_Data_t *address, uint32_t length);
 
 void ILI9341_SetOrientation(uint32_t Orientation);

--- a/Firmware/Test/Drivers/external/lcd.c
+++ b/Firmware/Test/Drivers/external/lcd.c
@@ -90,7 +90,9 @@ void LCD_FillRect(uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint16_t c)
 	ILI9341_SetDisplayWindow(x, y, w, h);
 
 #ifdef ILI9341_USEDMA
-	ILI9341_SendRepeatedDataDMA(c, pixel_count);
+	static uint16_t static_c;
+	static_c = c;
+	ILI9341_SendRepeatedDataDMA(&static_c, pixel_count);
 #else
 	ILI9341_SendRepeatedData(c, pixel_count);
 #endif

--- a/Firmware/Test/Drivers/external/lcd_ili9341.c
+++ b/Firmware/Test/Drivers/external/lcd_ili9341.c
@@ -158,7 +158,7 @@ int32_t ILI9341_SendDataDMA(LCD_IO_Data_t *data, uint32_t length)
  * @param data spremenljivka s podatkom
  * @param num_copies število kopij, ki se pošljejo
  */
-int32_t ILI9341_SendRepeatedDataDMA(LCD_IO_Data_t data, uint32_t num_copies)
+int32_t ILI9341_SendRepeatedDataDMA(LCD_IO_Data_t *data, uint32_t num_copies)
 {
 
 	uint32_t len, transfer;
@@ -196,7 +196,7 @@ int32_t ILI9341_SendRepeatedDataDMA(LCD_IO_Data_t data, uint32_t num_copies)
 			len = 0;
 		}
 		if (transfer == 0) return 1;
-		if (HAL_DMA_Start_IT(&hLCDDMA, (uint32_t) &data, (uint32_t)FMC_BANK1_MEM, transfer) != HAL_OK) return 1;
+		if (HAL_DMA_Start_IT(&hLCDDMA, (uint32_t) data, (uint32_t)FMC_BANK1_MEM, transfer) != HAL_OK) return 1;
 	}
 	while (len);
 


### PR DESCRIPTION
This commit fixes a problem with the LCD_FillRect function not working properly when using DMA to send data to the screen. When calling the function the area would start filling with the right color but then quickly switch to black (or sometimes a different color) before even finishing the first line.

The problem was in the ILI9341_SendRepeatedDataDMA function, which passed the address of a parameter variable (living on the stack) to the DMA function. After exiting, the address was no longer valid, but the DMA was still reading from it and writing its value to the screen. 

The ILI9341_SendRepeatedDataDMA function has been changed to accept an address instead of a value and the LCD_FillRect function has been changed to pass it the address of a static variable, so that the address will never become invalid.